### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-28
+
 ### Changed
 
-- Unified graph lookup names onto `:Abstract` (removed separate `:Identifier`). Routes, middleware, and dependencies now hook into the same container abstract nodes as `BINDS_TO`, so the graph stays continuously traversable.
+- Unified graph lookup names onto `:Abstract` (removed separate `:Identifier`). Routes, middleware, and dependencies now hook into the same container abstract nodes as `BINDS_TO`, so the graph stays continuously traversable. Re-running `container:graph` drops legacy `:Identifier` nodes.
+
 ## [1.1.0] - 2026-08-14
 
 ### Added
@@ -73,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public semver release under `neo4j/laravel-boost` (previously `1.0.0` placeholder in `composer.json`).
 
+[1.1.1]: https://github.com/neo4j-php/neo4j-boost/releases/tag/v1.1.1
 [1.1.0]: https://github.com/neo4j-php/neo4j-boost/releases/tag/v1.1.0
 [1.0.1]: https://github.com/neo4j-php/neo4j-boost/releases/tag/v1.0.1
 [1.0.0]: https://github.com/neo4j-php/neo4j-boost/releases/tag/v1.0.0

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "neo4j/laravel-boost",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Official Neo4j MCP server integration for Laravel",
     "type": "library",
     "license": "MIT",

--- a/docs/content-plan.md
+++ b/docs/content-plan.md
@@ -75,7 +75,7 @@ Do **not** duplicate these as separate tutorials. Tutorials should link out and 
 | Installation & transports | README → Installation / Configuration | Documentation/reference | `NEO4J_MCP_TRANSPORT` (`stdio` / `http` / `driver`), env vars, Docker MCP example | All users | Copy env blocks and commands from README | P0 | **Exists** |
 | Artisan command list | README → Artisan commands | Documentation/reference | Full command table including setup, doctor, test-stdio, container:graph | All users | `php artisan …` reference | P0 | **Exists** |
 | Cursor MCP entry shape | README → Single MCP server / Using with Cursor | Documentation/reference | `laravel-boost` → `php artisan boost:mcp` | Cursor users | JSON snippet in README | P0 | **Exists** |
-| Container graph model & Cypher | README → Exploring Your Container Dependency Graph | Documentation/reference | Route / Middleware / Instance / Abstract labels and example queries | Users exploring DI graphs | `MATCH path = (r:Route)-[:USES_MIDDLEWARE]->(:Middleware)…` | P0 | **Exists** |
+| Container graph model & Cypher | README → Exploring Your Container Dependency Graph | Documentation/reference | Route / Middleware / Instance / Abstract labels and continuous traversal via container abstracts | Users exploring DI graphs | `MATCH path = (r:Route)-[:HANDLED_BY]->(:Abstract)…` | P0 | **Exists** |
 | Troubleshooting | README → Troubleshooting | Documentation/reference | APP_ENV / MCP JSON / APOC / GDS / Docker host pitfalls | Users hitting errors | Error → fix bullets | P0 | **Exists** |
 | Release notes | `CHANGELOG.md` | Documentation/reference | Version history | All users | Link from README | P0 | **Exists** |
 

--- a/docs/tutorials/container-graph.md
+++ b/docs/tutorials/container-graph.md
@@ -56,7 +56,7 @@ Details: [README – Exploring Your Container Dependency Graph](../../README.md#
 | `:Dependency` | `key` | A dependency occurrence on an instance |
 | `:Abstract` | `name` | Container lookup key (class, interface, or alias) for handlers, middleware, dependencies, and bindings. Secondary labels: `Interface`, `Class`, `AbstractType`. |
 
-Bindings still also export `:Abstract` nodes with `BINDS_TO` (interface/class binding keys).
+Bindings use `BINDS_TO` between `:Abstract` nodes (with secondary labels `Interface` / `Class` / `AbstractType`).
 
 ### Runtime relationships
 


### PR DESCRIPTION
## Summary
- Bump package version to **1.1.1**.
- Finalize changelog for unifying `:Identifier` into `:Abstract` (continuous container graph).
- Small doc polish for the Abstract-centric model.

## Test plan
- [x] `composer ci`
- [ ] Merge to `main`
- [ ] Tag `v1.1.1` and publish GitHub release from the changelog section
- [ ] Confirm Packagist shows 1.1.1


Made with [Cursor](https://cursor.com)