### PR TITLE
Fix Abstract MERGE uniqueness constraint failures

### DIFF
--- a/src/ContainerGraphWriter.php
+++ b/src/ContainerGraphWriter.php
@@ -15,29 +15,19 @@ class ContainerGraphWriter
 {
     private const CYPHER_BINDINGS = <<<'CYPHER'
 UNWIND $rows AS row
-FOREACH (_ IN CASE WHEN row.abstractKind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (:Interface:Abstract {name: row.abstract})
-)
-FOREACH (_ IN CASE WHEN row.abstractKind = 'Class' THEN [1] ELSE [] END |
-  MERGE (:Class:Abstract {name: row.abstract})
-)
-FOREACH (_ IN CASE WHEN row.abstractKind <> 'Interface' AND row.abstractKind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (a:AbstractType:Abstract {name: row.abstract})
-  SET a.kind = row.abstractKind
-)
-FOREACH (_ IN CASE WHEN row.concreteKind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (:Interface:Abstract {name: row.concrete})
-)
-FOREACH (_ IN CASE WHEN row.concreteKind = 'Class' THEN [1] ELSE [] END |
-  MERGE (:Class:Abstract {name: row.concrete})
-)
-FOREACH (_ IN CASE WHEN row.concreteKind <> 'Interface' AND row.concreteKind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (c:AbstractType:Abstract {name: row.concrete})
-  SET c.kind = row.concreteKind
-)
-WITH row
-MATCH (a:Abstract {name: row.abstract})
-MATCH (c:Abstract {name: row.concrete})
+MERGE (a:Abstract {name: row.abstract})
+SET a.kind = row.abstractKind
+REMOVE a:Interface, a:Class, a:AbstractType
+FOREACH (_ IN CASE WHEN row.abstractKind = 'Interface' THEN [1] ELSE [] END | SET a:Interface)
+FOREACH (_ IN CASE WHEN row.abstractKind = 'Class' THEN [1] ELSE [] END | SET a:Class)
+FOREACH (_ IN CASE WHEN row.abstractKind <> 'Interface' AND row.abstractKind <> 'Class' THEN [1] ELSE [] END | SET a:AbstractType)
+WITH row, a
+MERGE (c:Abstract {name: row.concrete})
+SET c.kind = row.concreteKind
+REMOVE c:Interface, c:Class, c:AbstractType
+FOREACH (_ IN CASE WHEN row.concreteKind = 'Interface' THEN [1] ELSE [] END | SET c:Interface)
+FOREACH (_ IN CASE WHEN row.concreteKind = 'Class' THEN [1] ELSE [] END | SET c:Class)
+FOREACH (_ IN CASE WHEN row.concreteKind <> 'Interface' AND row.concreteKind <> 'Class' THEN [1] ELSE [] END | SET c:AbstractType)
 MERGE (a)-[r:BINDS_TO]->(c)
 SET r.type = row.type,
     r.source = row.source,
@@ -55,36 +45,24 @@ CYPHER;
 UNWIND $rows AS row
 MERGE (dep:Dependency {key: row.dependency_key})
 SET dep.access = row.access
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (:Interface:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END |
-  MERGE (:Class:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (:AbstractType:Abstract {name: row.identifier})
-)
-WITH row, dep
-MATCH (id:Abstract {name: row.identifier})
+MERGE (id:Abstract {name: row.identifier})
 SET id.kind = row.identifier_kind,
     id.reason = coalesce(row.reason, id.reason)
+REMOVE id:Interface, id:Class, id:AbstractType
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END | SET id:Interface)
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END | SET id:Class)
+FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END | SET id:AbstractType)
 MERGE (dep)-[:IDENTIFIED_AS]->(id)
 CYPHER;
 
     private const CYPHER_ABSTRACT_RESOLVES_TO = <<<'CYPHER'
 UNWIND $rows AS row
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (:Interface:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END |
-  MERGE (:Class:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (:AbstractType:Abstract {name: row.identifier})
-)
-WITH row
-MATCH (id:Abstract {name: row.identifier})
+MERGE (id:Abstract {name: row.identifier})
 SET id.kind = coalesce(row.identifier_kind, id.kind)
+REMOVE id:Interface, id:Class, id:AbstractType
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END | SET id:Interface)
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END | SET id:Class)
+FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END | SET id:AbstractType)
 MERGE (i:Instance {name: row.instance})
 MERGE (id)-[r:RESOLVES_TO]->(i)
 SET r.lifetime = row.lifetime
@@ -112,19 +90,13 @@ CYPHER;
     private const CYPHER_CONTEXTUAL_BINDS = <<<'CYPHER'
 UNWIND $rows AS row
 MERGE (i:Instance {name: row.when})
-FOREACH (_ IN CASE WHEN row.give_kind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (:Interface:Abstract {name: row.give})
-)
-FOREACH (_ IN CASE WHEN row.give_kind = 'Class' THEN [1] ELSE [] END |
-  MERGE (:Class:Abstract {name: row.give})
-)
-FOREACH (_ IN CASE WHEN row.give_kind <> 'Interface' AND row.give_kind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (:AbstractType:Abstract {name: row.give})
-)
-WITH row, i
-MATCH (g:Abstract {name: row.give})
+MERGE (g:Abstract {name: row.give})
 SET g.kind = row.give_kind,
     g.reason = CASE WHEN row.reason <> '' THEN row.reason ELSE g.reason END
+REMOVE g:Interface, g:Class, g:AbstractType
+FOREACH (_ IN CASE WHEN row.give_kind = 'Interface' THEN [1] ELSE [] END | SET g:Interface)
+FOREACH (_ IN CASE WHEN row.give_kind = 'Class' THEN [1] ELSE [] END | SET g:Class)
+FOREACH (_ IN CASE WHEN row.give_kind <> 'Interface' AND row.give_kind <> 'Class' THEN [1] ELSE [] END | SET g:AbstractType)
 MERGE (i)-[r:CONTEXTUAL_BINDS]->(g)
 SET r.needs = row.needs,
     r.needs_kind = row.needs_kind,
@@ -139,18 +111,12 @@ SET r.uri = row.uri,
     r.name = row.name,
     r.action = row.action
 REMOVE r.route_name
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (:Interface:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END |
-  MERGE (:Class:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (:AbstractType:Abstract {name: row.identifier})
-)
-WITH row, r
-MATCH (id:Abstract {name: row.identifier})
+MERGE (id:Abstract {name: row.identifier})
 SET id.kind = coalesce(row.identifier_kind, id.kind)
+REMOVE id:Interface, id:Class, id:AbstractType
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END | SET id:Interface)
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END | SET id:Class)
+FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END | SET id:AbstractType)
 MERGE (r)-[:HANDLED_BY]->(id)
 CYPHER;
 
@@ -159,18 +125,12 @@ UNWIND $rows AS row
 MERGE (r:Route {key: row.route_key})
 MERGE (m:Middleware {key: row.middleware_key})
 SET m.name = row.middleware_key
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (:Interface:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END |
-  MERGE (:Class:Abstract {name: row.identifier})
-)
-FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (:AbstractType:Abstract {name: row.identifier})
-)
-WITH row, r, m
-MATCH (id:Abstract {name: row.identifier})
+MERGE (id:Abstract {name: row.identifier})
 SET id.kind = coalesce(row.identifier_kind, id.kind)
+REMOVE id:Interface, id:Class, id:AbstractType
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Interface' THEN [1] ELSE [] END | SET id:Interface)
+FOREACH (_ IN CASE WHEN row.identifier_kind = 'Class' THEN [1] ELSE [] END | SET id:Class)
+FOREACH (_ IN CASE WHEN row.identifier_kind <> 'Interface' AND row.identifier_kind <> 'Class' THEN [1] ELSE [] END | SET id:AbstractType)
 MERGE (m)-[:IDENTIFIED_AS]->(id)
 MERGE (r)-[u:USES_MIDDLEWARE {order: row.order}]->(m)
 SET u.parameters = coalesce(row.parameters, '')

--- a/src/GraphKnowledgeContributor.php
+++ b/src/GraphKnowledgeContributor.php
@@ -23,43 +23,43 @@ class GraphKnowledgeContributor
     public const RELATIONSHIP_BINDS_TO = 'BINDS_TO';
 
     private const CYPHER_DEPENDS_ON = <<<'CYPHER'
-MERGE (c:Class:Abstract {name: $from})
+MERGE (c:Abstract {name: $from})
+SET c.kind = 'Class'
+REMOVE c:Interface, c:AbstractType
+SET c:Class
+WITH c
 FOREACH (_ IN CASE WHEN $toKind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (d:Interface:Abstract {name: $to})
+  MERGE (d:Abstract {name: $to})
+  SET d.kind = 'Interface'
+  REMOVE d:Class, d:AbstractType
+  SET d:Interface
   MERGE (c)-[r:DEPENDS_ON]->(d)
   SET r.type = $type, r.source = $source, r.confidence = $confidence, r.reason = $reason
 )
 FOREACH (_ IN CASE WHEN $toKind <> 'Interface' THEN [1] ELSE [] END |
-  MERGE (d:Class:Abstract {name: $to})
+  MERGE (d:Abstract {name: $to})
+  SET d.kind = 'Class'
+  REMOVE d:Interface, d:AbstractType
+  SET d:Class
   MERGE (c)-[r:DEPENDS_ON]->(d)
   SET r.type = $type, r.source = $source, r.confidence = $confidence, r.reason = $reason
 )
 CYPHER;
 
     private const CYPHER_BINDS_TO = <<<'CYPHER'
-FOREACH (_ IN CASE WHEN $fromKind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (a:Interface:Abstract {name: $from})
-)
-FOREACH (_ IN CASE WHEN $fromKind = 'Class' THEN [1] ELSE [] END |
-  MERGE (a:Class:Abstract {name: $from})
-)
-FOREACH (_ IN CASE WHEN $fromKind <> 'Interface' AND $fromKind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (a:AbstractType:Abstract {name: $from})
-  SET a.kind = $fromKind
-)
-FOREACH (_ IN CASE WHEN $toKind = 'Interface' THEN [1] ELSE [] END |
-  MERGE (c:Interface:Abstract {name: $to})
-)
-FOREACH (_ IN CASE WHEN $toKind = 'Class' THEN [1] ELSE [] END |
-  MERGE (c:Class:Abstract {name: $to})
-)
-FOREACH (_ IN CASE WHEN $toKind <> 'Interface' AND $toKind <> 'Class' THEN [1] ELSE [] END |
-  MERGE (c:AbstractType:Abstract {name: $to})
-  SET c.kind = $toKind
-)
-WITH 1 AS _
-MATCH (a:Abstract {name: $from})
-MATCH (c:Abstract {name: $to})
+MERGE (a:Abstract {name: $from})
+SET a.kind = $fromKind
+REMOVE a:Interface, a:Class, a:AbstractType
+FOREACH (_ IN CASE WHEN $fromKind = 'Interface' THEN [1] ELSE [] END | SET a:Interface)
+FOREACH (_ IN CASE WHEN $fromKind = 'Class' THEN [1] ELSE [] END | SET a:Class)
+FOREACH (_ IN CASE WHEN $fromKind <> 'Interface' AND $fromKind <> 'Class' THEN [1] ELSE [] END | SET a:AbstractType)
+WITH a
+MERGE (c:Abstract {name: $to})
+SET c.kind = $toKind
+REMOVE c:Interface, c:Class, c:AbstractType
+FOREACH (_ IN CASE WHEN $toKind = 'Interface' THEN [1] ELSE [] END | SET c:Interface)
+FOREACH (_ IN CASE WHEN $toKind = 'Class' THEN [1] ELSE [] END | SET c:Class)
+FOREACH (_ IN CASE WHEN $toKind <> 'Interface' AND $toKind <> 'Class' THEN [1] ELSE [] END | SET c:AbstractType)
 MERGE (a)-[r:BINDS_TO]->(c)
 SET r.type = $type, r.source = $source, r.confidence = $confidence, r.reason = $reason
 CYPHER;

--- a/tests/Integration/ContainerGraphWriterTest.php
+++ b/tests/Integration/ContainerGraphWriterTest.php
@@ -24,8 +24,11 @@ class ContainerGraphWriterTest extends TestCase
         $bindingsTemplate = $writer->cypherTemplates()['bindings'];
 
         $this->assertStringContainsString('row.concreteKind', $bindingsTemplate);
-        $this->assertStringContainsString('AbstractType:Abstract', $bindingsTemplate);
+        $this->assertStringContainsString('MERGE (a:Abstract {name: row.abstract})', $bindingsTemplate);
+        $this->assertStringContainsString('MERGE (c:Abstract {name: row.concrete})', $bindingsTemplate);
+        $this->assertStringContainsString('SET a:AbstractType', $bindingsTemplate);
         $this->assertStringContainsString('r.type = row.type', $bindingsTemplate);
+        $this->assertStringNotContainsString('MERGE (:Interface:Abstract', $bindingsTemplate);
     }
 
     public function test_instance_depends_on_cypher_sets_metadata_on_edges(): void
@@ -65,9 +68,10 @@ class ContainerGraphWriterTest extends TestCase
 
         $this->assertStringContainsString('IDENTIFIED_AS', $template);
         $this->assertStringContainsString('dep.access = row.access', $template);
-        $this->assertStringContainsString(':Abstract', $template);
+        $this->assertStringContainsString('MERGE (id:Abstract {name: row.identifier})', $template);
         $this->assertStringContainsString(':Dependency', $template);
         $this->assertStringNotContainsString(':Identifier', $template);
+        $this->assertStringNotContainsString('MERGE (:Interface:Abstract', $template);
     }
 
     public function test_abstract_resolves_to_cypher_sets_lifetime(): void


### PR DESCRIPTION
## Summary
- Merge Abstract nodes on `:Abstract {name}` alone, then apply `Interface` / `Class` / `AbstractType` labels afterward.
- Avoids `ConstraintValidationFailed` when the same lookup name (e.g. `auth`) is written with different secondary labels across graph templates.
- Verified in BMS: `container:graph` succeeds; zero `:Identifier` nodes; no duplicate `Abstract.name`.

## Test plan
- [x] `composer ci` (pint, phpstan, phpunit)
- [x] Re-run `php artisan container:graph` against BMS Neo4j cluster
- [ ] Confirm Browser checks: no `:Identifier`, no duplicate `Abstract.name`, continuous `Route → Abstract → Instance` paths


Made with [Cursor](https://cursor.com)